### PR TITLE
Support parsing enum

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
  * Copy `serde-yaml` test code
  * Use YAML SPEC examples as test data
- * Handle tag
  * Handle directive
  * Handle anchor
+ * JSON(Flow Sequences mode) support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod scalar_str;
 mod token;
 mod token_iter;
 mod value;
+mod variant;
 
 pub(crate) use self::array::{get_array, YamlValueSeqAccess};
 pub(crate) use self::char_iter::CharsIter;
@@ -21,9 +22,10 @@ pub(crate) use self::scalar_str::{
 };
 pub(crate) use self::token::{YamlToken, YamlTokenData, YAML_CHAR_INDICATORS};
 pub(crate) use self::token_iter::TokensIter;
+pub(crate) use self::variant::{get_tag, YamlValueEnumAccess};
 
 pub use self::deserializer::{from_str, RmsdDeserializer};
 pub use self::error::RmsdError;
 pub use self::map::YamlValueMap;
 pub use self::position::RmsdPosition;
-pub use self::value::{YamlValue, YamlValueData};
+pub use self::value::{YamlTag, YamlValue, YamlValueData};

--- a/src/variant.rs
+++ b/src/variant.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::de::{
+    DeserializeSeed, Deserializer, EnumAccess, VariantAccess, Visitor,
+};
+
+use crate::{
+    RmsdDeserializer, RmsdError, RmsdPosition, TokensIter, YamlTag,
+    YamlTokenData, YamlValue, YamlValueData,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct YamlValueEnumAccess {
+    value: YamlValue,
+}
+
+impl YamlValueEnumAccess {
+    pub(crate) fn new(value: YamlValue) -> Self {
+        Self { value }
+    }
+}
+
+impl<'de> VariantAccess<'de> for YamlValueEnumAccess {
+    type Error = RmsdError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        if matches!(self.value.data, YamlValueData::Scalar(_)) {
+            Ok(())
+        } else {
+            Err(RmsdError::unexpected_yaml_node_type(
+                format!(
+                    "Expecting enum/variant string, but got {}",
+                    self.value.data
+                ),
+                RmsdPosition::EOF,
+            ))
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        if let YamlValueData::Tag(tag) = &self.value.data {
+            let value = YamlValue {
+                start: self.value.start,
+                end: self.value.end,
+                data: tag.data.clone(),
+            };
+            seed.deserialize(&mut RmsdDeserializer { parsed: value })
+        } else {
+            seed.deserialize(&mut RmsdDeserializer {
+                parsed: self.value.clone(),
+            })
+        }
+    }
+
+    fn tuple_variant<V>(
+        self,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        RmsdDeserializer {
+            parsed: self.value.clone(),
+        }
+        .deserialize_seq(visitor)
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        RmsdDeserializer {
+            parsed: self.value.clone(),
+        }
+        .deserialize_map(visitor)
+    }
+}
+
+impl<'de> EnumAccess<'de> for YamlValueEnumAccess {
+    type Error = RmsdError;
+    type Variant = Self;
+
+    fn variant_seed<V>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let val = seed.deserialize(&mut RmsdDeserializer {
+            parsed: self.value.clone(),
+        })?;
+        Ok((val, self))
+    }
+}
+
+pub(crate) fn get_tag(iter: &mut TokensIter) -> Result<YamlTag, RmsdError> {
+    if let Some(token) = iter.next() {
+        if let YamlTokenData::LocalTag(name) = token.data {
+            let data_tokens = iter.remove_tokens_with_the_same_indent();
+            Ok(YamlTag {
+                name,
+                data: YamlValue::try_from(data_tokens)?.data,
+            })
+        } else {
+            Err(RmsdError::unexpected_yaml_node_type(
+                format!(
+                    "get_tag() been invoked against TokenIter not leading \
+                    with LocalTag but {}",
+                    token.data
+                ),
+                token.start,
+            ))
+        }
+    } else {
+        Err(RmsdError::bug(
+            "get_tag() been invoked against empty TokenIter".to_string(),
+            RmsdPosition::EOF,
+        ))
+    }
+}

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -3,14 +3,16 @@
 use pretty_assertions::assert_eq;
 use serde::{Deserialize, Serialize};
 
+use rmsd_yaml::RmsdError;
+
 #[test]
-fn test_de_char() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_char() -> Result<(), RmsdError> {
     assert_eq!(rmsd_yaml::from_str::<char>("q")?, 'q');
     Ok(())
 }
 
 #[test]
-fn test_de_str() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_str() -> Result<(), RmsdError> {
     let yaml_str = r#"
         "acb"
     "#;
@@ -21,7 +23,7 @@ fn test_de_str() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_bool() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_bool() -> Result<(), RmsdError> {
     assert!(!rmsd_yaml::from_str("false")?);
 
     assert!(rmsd_yaml::from_str("true")?);
@@ -29,7 +31,7 @@ fn test_de_bool() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_unsign_number() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_unsign_number() -> Result<(), RmsdError> {
     assert_eq!(123114u32, rmsd_yaml::from_str("\n---\n123114")?);
 
     assert_eq!(1234u16, rmsd_yaml::from_str("+1234")?);
@@ -42,7 +44,7 @@ fn test_de_unsign_number() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_struct() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_struct() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest {
         uint_a: u32,
@@ -77,7 +79,7 @@ fn test_de_struct() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_array() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_array() -> Result<(), RmsdError> {
     let yaml_str = r#"
         ---
         - 500
@@ -92,7 +94,7 @@ fn test_de_array() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_tuple() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_tuple() -> Result<(), RmsdError> {
     let yaml_str = r#"
         ---
         - 500
@@ -106,7 +108,7 @@ fn test_de_tuple() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_tuple_of_struct() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_tuple_of_struct() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest {
         uint_a: u32,
@@ -140,7 +142,7 @@ fn test_de_tuple_of_struct() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_array_of_struct() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_array_of_struct() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest {
         uint_a: u32,
@@ -174,7 +176,7 @@ fn test_de_array_of_struct() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn test_de_new_type_struct() -> Result<(), Box<dyn std::error::Error>> {
+fn test_de_new_type_struct() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest(String);
 
@@ -186,5 +188,100 @@ fn test_de_new_type_struct() -> Result<(), Box<dyn std::error::Error>> {
     let value: FooTest = rmsd_yaml::from_str(yaml_str)?;
 
     assert_eq!(value, FooTest("abcedfo".to_string()));
+    Ok(())
+}
+
+#[test]
+fn test_de_enum() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    enum FooTest {
+        Abc,
+        Abd,
+        Abe,
+    }
+
+    assert_eq!(FooTest::Abe, rmsd_yaml::from_str("Abe")?);
+
+    Ok(())
+}
+
+#[test]
+fn test_de_enum_new_type_struct() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    enum FooTest {
+        Abc(u32),
+        Abd(u64),
+        Abe(u8),
+    }
+
+    assert_eq!(
+        FooTest::Abe(128),
+        rmsd_yaml::from_str::<FooTest>("!Abe 128")?
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_de_enum_new_type_struct_string() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    enum FooTest {
+        Abc(String),
+        Abd(String),
+        Abe(String),
+    }
+
+    assert_eq!(
+        FooTest::Abe("128".into()),
+        rmsd_yaml::from_str::<FooTest>("!Abe 128")?
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_de_array_of_enum_of_struct() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: u32,
+        str_b: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct BarTest {
+        uint_b: u32,
+        str_c: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    enum EnumTest {
+        Foo(FooTest),
+        Bar(BarTest),
+    }
+
+    assert_eq!(
+        vec![
+            EnumTest::Foo(FooTest {
+                uint_a: 128,
+                str_b: "foo".into(),
+            }),
+            EnumTest::Bar(BarTest {
+                uint_b: 129,
+                str_c: "bar".into(),
+            }),
+        ],
+        rmsd_yaml::from_str::<Vec<EnumTest>>(
+            r#"
+            ---
+            - !Foo
+              uint_a: 128
+              str_b: foo
+            - !Bar
+              uint_b: 129
+              str_c: bar
+            "#
+        )?
+    );
+
     Ok(())
 }


### PR DESCRIPTION
Support these these types of enum:

```rust
struct Bar {
    val1: u64,
}

enum Foo {
   Item1,
   Item2(String),
   Item3(Bar),
}
```

Tests are included.