### PR TITLE
Initial support of flow(json) style

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -3,54 +3,99 @@
 use serde::de::{DeserializeSeed, SeqAccess};
 
 use crate::{
-    RmsdDeserializer, RmsdError, TokensIter, YamlToken, YamlTokenData,
-    YamlValue,
+    get_map, get_tag, RmsdDeserializer, RmsdError, RmsdPosition, TokensIter,
+    YamlTokenData, YamlValue, YamlValueData,
 };
 
+// Should have leading [ and tailing ] removed.
+// With `in_flow` set to true, we will read till end of iter without checking
+// indents.
 pub(crate) fn get_array(
     iter: &mut TokensIter,
-) -> Result<Vec<YamlValue>, RmsdError> {
-    let mut ret: Vec<YamlValue> = Vec::new();
-
-    let indent = if let Some(first_token) = iter.peek() {
-        first_token.indent
+    in_flow: bool,
+) -> Result<YamlValue, RmsdError> {
+    let mut items = Vec::new();
+    let (start, mut end, indent) = if let Some(first_token) = iter.peek() {
+        (first_token.start, first_token.end, first_token.indent)
     } else {
-        return Ok(ret);
+        return Err(RmsdError::bug(
+            "get_array(): Got empty tokens".to_string(),
+            RmsdPosition::EOF,
+        ));
     };
 
+    let mut previous_element_tokens = Vec::new();
+
     while let Some(token) = iter.peek() {
-        if token.indent < indent {
-            return Ok(ret);
+        if (!in_flow) && token.indent < indent {
+            break;
         }
-        if token.data == YamlTokenData::BlockSequenceIndicator {
-            iter.next();
-            let entry_tokens = get_seq_element_tokens(iter, indent);
-            ret.push(YamlValue::try_from(entry_tokens)?);
+        match token.data {
+            YamlTokenData::BlockSequenceIndicator => {
+                if in_flow {
+                    return Err(RmsdError::unexpected_yaml_node_type(
+                        "Cannot place - right after [".to_string(),
+                        token.start,
+                    ));
+                } else {
+                    if !previous_element_tokens.is_empty() {
+                        items.push(YamlValue::parse(&mut TokensIter::new(
+                            std::mem::take(&mut previous_element_tokens),
+                        ))?);
+                    }
+                    iter.next();
+                }
+            }
+            YamlTokenData::FlowSequenceStart => {
+                let mut element_iter =
+                    TokensIter::new(iter.remove_tokens_of_seq_flow()?);
+                items.push(get_array(&mut element_iter, true)?);
+            }
+            YamlTokenData::FlowMapStart => {
+                let mut element_iter =
+                    TokensIter::new(iter.remove_tokens_of_map_flow()?);
+                items.push(get_map(&mut element_iter, true)?);
+            }
+            YamlTokenData::CollectEntry => {
+                // We will have empty previous_element_tokens for `,` after `{}`
+                // or `[]`.
+                if !previous_element_tokens.is_empty() {
+                    items.push(YamlValue::parse(&mut TokensIter::new(
+                        std::mem::take(&mut previous_element_tokens),
+                    ))?);
+                }
+                iter.next();
+            }
+            YamlTokenData::Scalar(_) => {
+                previous_element_tokens.push(iter.next().unwrap());
+            }
+            YamlTokenData::MapValueIndicator => {
+                previous_element_tokens.push(iter.next().unwrap());
+            }
+            YamlTokenData::LocalTag(_) => {
+                items.push(get_tag(iter)?);
+            }
+            _ => {
+                return Err(RmsdError::bug(
+                    format!("get_array(): Unexpected token {token:?}"),
+                    token.start,
+                ));
+            }
         }
     }
-
-    Ok(ret)
-}
-
-/// Take token until:
-/// * indent miss-match
-/// * reach another `-` with the same indent
-fn get_seq_element_tokens(
-    iter: &mut TokensIter,
-    indent: usize,
-) -> Vec<YamlToken> {
-    let mut ret = Vec::new();
-    while let Some(token) = iter.peek() {
-        if token.indent < indent
-            || token.data == YamlTokenData::BlockSequenceIndicator
-        {
-            return ret;
-        } else {
-            let token = iter.next().unwrap();
-            ret.push(token);
-        }
+    if !previous_element_tokens.is_empty() {
+        items.push(YamlValue::parse(&mut TokensIter::new(
+            previous_element_tokens,
+        ))?);
     }
-    ret
+    if !items.is_empty() {
+        end = items[items.len() - 1].end
+    }
+    Ok(YamlValue {
+        start,
+        end,
+        data: YamlValueData::Sequence(items),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -20,6 +20,7 @@ where
     T: Deserialize<'a>,
 {
     let parsed = YamlValue::from_str(s)?;
+    println!("HAHA {:?}", parsed);
     let mut deserializer = RmsdDeserializer { parsed };
 
     T::deserialize(&mut deserializer)

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,10 @@ pub enum ErrorKind {
     InvalidNumber,
     /// Number overflow
     NumberOverflow,
+    /// Unfinished map indicator `{`
+    UnfinishedMapIndicator,
+    /// Unfinished map indicator `[`
+    UnfinishedSequenceIndicator,
 }
 
 impl std::fmt::Display for ErrorKind {
@@ -43,6 +47,9 @@ impl std::fmt::Display for ErrorKind {
                 Self::InvalidBool => "invalid_bool",
                 Self::InvalidNumber => "invalid_number",
                 Self::NumberOverflow => "number_overflow",
+                Self::UnfinishedMapIndicator => "unfinished_map_indicator",
+                Self::UnfinishedSequenceIndicator =>
+                    "unfinished_sequence_indicator",
             }
         )
     }
@@ -63,6 +70,10 @@ impl TryFrom<&str> for ErrorKind {
             "invalid_bool" => Self::InvalidBool,
             "invalid_number" => Self::InvalidNumber,
             "number_overflow" => Self::NumberOverflow,
+            "unfinished_map_indicator" => Self::UnfinishedMapIndicator,
+            "unfinished_sequence_indicator" => {
+                Self::UnfinishedSequenceIndicator
+            }
             _ => {
                 return Err(RmsdError::new(
                     ErrorKind::InvalidErrorType,
@@ -212,6 +223,22 @@ impl RmsdError {
         Self {
             kind: ErrorKind::NumberOverflow,
             msg,
+            pos,
+        }
+    }
+
+    pub(crate) fn unfinished_map_indicator(pos: RmsdPosition) -> Self {
+        Self {
+            kind: ErrorKind::UnfinishedMapIndicator,
+            msg: "Unfinished map indicator `}`".to_string(),
+            pos,
+        }
+    }
+
+    pub(crate) fn unfinished_seq_indicator(pos: RmsdPosition) -> Self {
+        Self {
+            kind: ErrorKind::UnfinishedSequenceIndicator,
+            msg: "Unfinished sequence indicator `]`".to_string(),
             pos,
         }
     }

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -285,3 +285,37 @@ fn test_de_array_of_enum_of_struct() -> Result<(), RmsdError> {
 
     Ok(())
 }
+
+#[test]
+fn test_de_struct_with_enum_member() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: EnumTest,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    enum EnumTest {
+        Bar(BarTest),
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct BarTest {
+        uint_b: u32,
+    }
+
+    assert_eq!(
+        FooTest {
+            uint_a: EnumTest::Bar(BarTest { uint_b: 32 })
+        },
+        rmsd_yaml::from_str::<FooTest>(
+            r#"
+            ---
+            uint_a:
+              !Bar
+              uint_b: 32
+            "#
+        )?
+    );
+
+    Ok(())
+}

--- a/tests/from_str_flow.rs
+++ b/tests/from_str_flow.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use pretty_assertions::assert_eq;
+use serde::{Deserialize, Serialize};
+
+use rmsd_yaml::RmsdError;
+
+#[test]
+fn test_de_yaml_flow_style_struct() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: u32,
+        str_b: String,
+        bar: BarTest,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct BarTest {
+        data: bool,
+    }
+
+    let yaml_str = r#"{ uint_a: 500, str_b: "abc", bar: {data: false}}"#;
+
+    let foo_test: FooTest = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        foo_test,
+        FooTest {
+            uint_a: 500,
+            str_b: "abc".to_string(),
+            bar: BarTest { data: false }
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_mix_flow_and_block_style_on_dict() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: u32,
+        str_b: String,
+        bar: BarTest,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct BarTest {
+        data: bool,
+    }
+
+    let yaml_str = r#"{ uint_a: 500, str_b: "abc",
+    bar: {data: false}}"#;
+
+    let foo_test: FooTest = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        foo_test,
+        FooTest {
+            uint_a: 500,
+            str_b: "abc".to_string(),
+            bar: BarTest { data: false }
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_json_struct() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: u32,
+        str_b: String,
+        bar: BarTest,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct BarTest {
+        data: bool,
+    }
+
+    let yaml_str = r#"{
+  "uint_a": 500,
+  "str_b": "abc",
+  "bar": {
+    "data": false
+  }
+}"#;
+
+    let foo_test: FooTest = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        foo_test,
+        FooTest {
+            uint_a: 500,
+            str_b: "abc".to_string(),
+            bar: BarTest { data: false }
+        }
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_style_array() -> Result<(), RmsdError> {
+    let yaml_str = r#"[1,2,3,4]"#;
+
+    let foo_test: Vec<u8> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(foo_test, vec![1u8, 2, 3, 4]);
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_style_nested_array() -> Result<(), RmsdError> {
+    let yaml_str = r#"[[1,2,3,4], [2,3,4,5]]"#;
+
+    let foo_test: Vec<Vec<u8>> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(foo_test, vec![vec![1u8, 2, 3, 4], vec![2u8, 3, 4, 5]]);
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_mix_flow_and_block_array() -> Result<(), RmsdError> {
+    let yaml_str = r#"
+    - [1,2,3,4]
+    - [2,3,4,5]"#;
+
+    let foo_test: Vec<Vec<u8>> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(foo_test, vec![vec![1u8, 2, 3, 4], vec![2u8, 3, 4, 5]]);
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_array_of_struct() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: u32,
+        str_b: String,
+    }
+    let yaml_str = r#"
+    [{uint_a: 3, str_b: iterm1 },
+     {uint_a: 4, str_b: iterm2 }]
+    "#;
+
+    let foo_test: Vec<FooTest> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        foo_test,
+        vec![
+            FooTest {
+                uint_a: 3,
+                str_b: "iterm1".to_string(),
+            },
+            FooTest {
+                uint_a: 4,
+                str_b: "iterm2".to_string(),
+            }
+        ]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_struct_of_array() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        uint_a: Vec<u32>,
+    }
+    let yaml_str = r#"{uint_a: [1, 2, 3, 4]}"#;
+
+    let foo_test: FooTest = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        foo_test,
+        FooTest {
+            uint_a: vec![1, 2, 3, 4]
+        }
+    );
+    Ok(())
+}


### PR DESCRIPTION
Support these flow style of YAML (JSON like). For example:

```yml
[{uint_a: 3, str_b: iterm1 },
 {uint_a: 4, str_b: iterm2 }]
```

Integration test case included.