### PR TITLE
Change `to_string()` to use default opt

### DIFF
--- a/examples/to_yaml_string.rs
+++ b/examples/to_yaml_string.rs
@@ -27,6 +27,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             bar: BarTest { data: true },
         },
     ];
-    println!("{}", rmsd_yaml::to_string(&data, Default::default())?);
+    println!("{}", rmsd_yaml::to_string(&data)?);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,5 +30,7 @@ pub use self::deserializer::{from_str, to_value, RmsdDeserializer};
 pub use self::error::{ErrorKind, RmsdError};
 pub use self::map::YamlValueMap;
 pub use self::position::RmsdPosition;
-pub use self::serializer::{to_string, RmsdSerializeOption, RmsdSerializer};
+pub use self::serializer::{
+    to_string, to_string_with_opt, RmsdSerializeOption, RmsdSerializer,
+};
 pub use self::value::{YamlTag, YamlValue, YamlValueData};

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -39,7 +39,7 @@ pub struct RmsdSerializer {
     current_indent_level: usize,
 }
 
-pub fn to_string<T>(
+pub fn to_string_with_opt<T>(
     value: &T,
     option: RmsdSerializeOption,
 ) -> Result<String, RmsdError>
@@ -63,6 +63,13 @@ where
         serializer.output.pop();
     }
     Ok(serializer.output)
+}
+
+pub fn to_string<T>(value: &T) -> Result<String, RmsdError>
+where
+    T: Serialize,
+{
+    to_string_with_opt(value, RmsdSerializeOption::default())
 }
 
 impl RmsdSerializer {
@@ -516,7 +523,7 @@ mod tests {
             indent_count: 1,
             ..Default::default()
         };
-        let result = to_string(&"abc", opt);
+        let result = to_string_with_opt(&"abc", opt);
 
         assert!(result.is_err());
         if let Err(e) = result {

--- a/tests/to_string.rs
+++ b/tests/to_string.rs
@@ -19,7 +19,7 @@ fn test_struct_to_string() -> Result<(), RmsdError> {
         bool_c: false,
     };
 
-    let yaml_str = rmsd_yaml::to_string(&data, Default::default())?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, Default::default())?;
 
     assert_eq!(
         yaml_str,
@@ -35,7 +35,7 @@ bool_c: false"#
 #[test]
 fn test_array_to_string() -> Result<(), RmsdError> {
     let data = vec![1u8, 2, 3, 4];
-    let yaml_str = rmsd_yaml::to_string(&data, Default::default())?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, Default::default())?;
 
     assert_eq!(yaml_str, "- 1\n- 2\n- 3\n- 4");
 
@@ -67,7 +67,7 @@ fn test_array_of_map() -> Result<(), RmsdError> {
     let mut opt = RmsdSerializeOption::default();
     opt.leading_start_indicator = true;
 
-    let yaml_str = rmsd_yaml::to_string(&data, opt)?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, opt)?;
 
     assert_eq!(
         yaml_str,
@@ -99,7 +99,7 @@ fn test_array_in_map() -> Result<(), RmsdError> {
     let mut opt = RmsdSerializeOption::default();
     opt.leading_start_indicator = true;
 
-    let yaml_str = rmsd_yaml::to_string(&data, opt)?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, opt)?;
 
     assert_eq!(
         yaml_str,
@@ -120,7 +120,7 @@ fn test_nested_array() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest(Vec<Vec<u32>>);
     let data = FooTest(vec![vec![1, 2, 3, 4], vec![5, 6, 7, 8]]);
-    let yaml_str = rmsd_yaml::to_string(&data, Default::default())?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, Default::default())?;
 
     assert_eq!(
         yaml_str,
@@ -160,7 +160,7 @@ fn test_nested_map() -> Result<(), RmsdError> {
         },
     };
 
-    let yaml_str = rmsd_yaml::to_string(&data, Default::default())?;
+    let yaml_str = rmsd_yaml::to_string_with_opt(&data, Default::default())?;
 
     assert_eq!(
         yaml_str,


### PR DESCRIPTION
In order to be drop-in replacement of `serde_yaml`, changed
`to_string()` to accept value as only argument using default
`RmsdSerializeOption`.

Introduced `to_string_with_opt()` for advanced user.