### PR TITLE
Support hyphen for unquoted string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) use self::scalar_str::{
     read_double_quoted_str, read_single_quoted_str, read_unquoted_str,
     to_scalar_string,
 };
-pub(crate) use self::token::{YamlToken, YamlTokenData, YAML_CHAR_INDICATORS};
+pub(crate) use self::token::{YamlToken, YamlTokenData};
 pub(crate) use self::token_iter::TokensIter;
 pub(crate) use self::variant::{get_tag, YamlValueEnumAccess};
 

--- a/tests/from_str_flow.rs
+++ b/tests/from_str_flow.rs
@@ -165,9 +165,10 @@ fn test_de_yaml_flow_array_of_struct() -> Result<(), RmsdError> {
 fn test_de_yaml_flow_struct_of_array() -> Result<(), RmsdError> {
     #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
     struct FooTest {
+        #[serde(rename = "uint-a")]
         uint_a: Vec<u32>,
     }
-    let yaml_str = r#"{uint_a: [1, 2, 3, 4]}"#;
+    let yaml_str = r#"{uint-a: [1, 2, 3, 4]}"#;
 
     let foo_test: FooTest = rmsd_yaml::from_str(yaml_str)?;
 


### PR DESCRIPTION
For YAML like:

`abc-d: 123`

It should be treated as Map with `abc-d` as key and `123` as value.

Test cases included.