### PR TITLE
Fix empty array/map support

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -329,4 +329,8 @@ impl<'de> Deserializer<'de> for &mut RmsdDeserializer {
     {
         self.deserialize_any(visitor)
     }
+
+    fn is_human_readable(&self) -> bool {
+        true
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -172,17 +172,6 @@ impl serde::de::Error for RmsdError {
         }
     }
 
-    fn invalid_type(
-        unexp: serde::de::Unexpected<'_>,
-        exp: &dyn serde::de::Expected,
-    ) -> Self {
-        // TODO: Find postion of this unexpected property
-        Self::unexpected_yaml_node_type(
-            format!("Expecting {exp} but got {unexp}"),
-            Default::default(),
-        )
-    }
-
     // TOOD: Implement more functions of this trait with position stored in
     // error.
 }

--- a/src/scalar_str.rs
+++ b/src/scalar_str.rs
@@ -131,7 +131,6 @@ pub(crate) fn read_unquoted_str(
             if let Some(next_line) =
                 iter.as_str().lines().nth(1).map(|s| s.trim_start())
             {
-                println!("HAHA {:?}", next_line);
                 if next_line.contains(": ")
                     || next_line.starts_with("- ")
                     || next_line.starts_with("---\n")

--- a/src/token.rs
+++ b/src/token.rs
@@ -288,9 +288,6 @@ impl YamlToken {
                 }
             }
         }
-        for token in &ret {
-            println!("HAHA {:?}", token.data);
-        }
         Ok(ret)
     }
 }

--- a/tests/from_str_flow.rs
+++ b/tests/from_str_flow.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use pretty_assertions::assert_eq;
 use serde::{Deserialize, Serialize};
 
@@ -177,6 +179,104 @@ fn test_de_yaml_flow_struct_of_array() -> Result<(), RmsdError> {
         FooTest {
             uint_a: vec![1, 2, 3, 4]
         }
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_empty_array() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct Iface {
+        name: String,
+        ethernet: EthernetIface,
+    }
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct EthernetIface {
+        #[serde(rename = "sr-iov")]
+        sr_iov: SriovConf,
+    }
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct SriovConf {
+        #[serde(rename = "total-vfs")]
+        total_vfs: u32,
+        vfs: Vec<VfsConf>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct VfsConf {
+        mac: String,
+    }
+
+    let yaml_str = r#"
+    - name: eth1
+      ethernet:
+        sr-iov:
+          total-vfs: 2
+          vfs: []
+    "#;
+
+    let iface_test: Vec<Iface> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        iface_test,
+        vec![Iface {
+            name: "eth1".into(),
+            ethernet: EthernetIface {
+                sr_iov: SriovConf {
+                    total_vfs: 2,
+                    vfs: Vec::new(),
+                }
+            }
+        }]
+    );
+    Ok(())
+}
+
+#[test]
+fn test_de_yaml_flow_empty_map() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct Iface {
+        name: String,
+        ethernet: EthernetIface,
+    }
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct EthernetIface {
+        #[serde(rename = "sr-iov")]
+        sr_iov: SriovConf,
+    }
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct SriovConf {
+        #[serde(rename = "total-vfs")]
+        total_vfs: u32,
+        vfs: HashMap<u32, VfsConf>,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct VfsConf {
+        mac: String,
+    }
+
+    let yaml_str = r#"
+    - name: eth1
+      ethernet:
+        sr-iov:
+          total-vfs: 2
+          vfs: {}
+    "#;
+
+    let iface_test: Vec<Iface> = rmsd_yaml::from_str(yaml_str)?;
+
+    assert_eq!(
+        iface_test,
+        vec![Iface {
+            name: "eth1".into(),
+            ethernet: EthernetIface {
+                sr_iov: SriovConf {
+                    total_vfs: 2,
+                    vfs: HashMap::new(),
+                }
+            }
+        }]
     );
     Ok(())
 }


### PR DESCRIPTION
Fix error when processing YAML contains empty array or map:

```yml
- name: eth1
  ethernet:
    sr-iov:
      total-vfs: 2
      vfs: []
```

```yml
- name: eth1
  ethernet:
    sr-iov:
      total-vfs: 2
      vfs: {}
```

Test cases included.