### PR TITLE
Fix error on parsing NULL input

### DIFF
--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -280,6 +280,9 @@ impl<'de> Deserializer<'de> for &mut RmsdDeserializer {
             // where we can use `Option::take()` to move data out.
             let access = YamlValueMapAccess::new(*v.clone());
             visitor.visit_map(access)
+        } else if let YamlValueData::Null = &self.parsed.data {
+            let access = YamlValueMapAccess::new(Default::default());
+            visitor.visit_map(access)
         } else {
             Err(RmsdError::unexpected_yaml_node_type(
                 format!("Expecting a map, got {}", self.parsed.data),

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use crate::{
     YamlTokenData, YamlValue, YamlValueData,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct YamlValueMap(IndexMap<YamlValue, YamlValue>);
 
 impl std::hash::Hash for YamlValueMap {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -59,8 +59,11 @@ where
         ..Default::default()
     };
     value.serialize(&mut serializer)?;
-    if serializer.output.ends_with("\n") {
+    if serializer.output.ends_with("\n\n") {
         serializer.output.pop();
+    }
+    if !serializer.output.ends_with("\n") {
+        serializer.output.push('\n');
     }
     Ok(serializer.output)
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -60,7 +60,7 @@ impl YamlValue {
             // The `as_str()` is called to get tag name of enum instead of
             // content.
             Ok(tag.name.as_str())
-        } else if &self.data == &YamlValueData::Null {
+        } else if self.data == YamlValueData::Null {
             Ok("")
         } else {
             Err(RmsdError::unexpected_yaml_node_type(
@@ -307,6 +307,11 @@ impl YamlValue {
                 }
                 YamlTokenData::MapKeyIndicator => get_map(iter, false),
                 YamlTokenData::LocalTag(_) => get_tag(iter),
+                YamlTokenData::Null => Ok(YamlValue {
+                    start: token.start,
+                    end: token.end,
+                    data: YamlValueData::Null,
+                }),
                 _ => {
                     if iter.data.get(1).and_then(|t| {
                         t.as_ref()

--- a/src/value.rs
+++ b/src/value.rs
@@ -60,6 +60,8 @@ impl YamlValue {
             // The `as_str()` is called to get tag name of enum instead of
             // content.
             Ok(tag.name.as_str())
+        } else if &self.data == &YamlValueData::Null {
+            Ok("")
         } else {
             Err(RmsdError::unexpected_yaml_node_type(
                 format!("Expecting a string, but got {}", &self.data),

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -338,3 +338,15 @@ fn test_signed_interger() -> Result<(), RmsdError> {
     );
     Ok(())
 }
+
+#[test]
+fn test_empty_input() -> Result<(), RmsdError> {
+    #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+    struct FooTest {
+        #[serde(default)]
+        uint_a: u32,
+    }
+
+    assert_eq!(FooTest { uint_a: 0 }, rmsd_yaml::from_str::<FooTest>("")?);
+    Ok(())
+}

--- a/tests/to_string.rs
+++ b/tests/to_string.rs
@@ -25,7 +25,8 @@ fn test_struct_to_string() -> Result<(), RmsdError> {
         yaml_str,
         r#"uint_a: 129
 str_b: abc
-bool_c: false"#
+bool_c: false
+"#
     );
 
     assert_eq!(rmsd_yaml::from_str::<FooTest>(&yaml_str)?, data);
@@ -37,7 +38,7 @@ fn test_array_to_string() -> Result<(), RmsdError> {
     let data = vec![1u8, 2, 3, 4];
     let yaml_str = rmsd_yaml::to_string_with_opt(&data, Default::default())?;
 
-    assert_eq!(yaml_str, "- 1\n- 2\n- 3\n- 4");
+    assert_eq!(yaml_str, "- 1\n- 2\n- 3\n- 4\n");
 
     assert_eq!(rmsd_yaml::from_str::<Vec<u8>>(&yaml_str)?, data);
     Ok(())
@@ -77,7 +78,8 @@ fn test_array_of_map() -> Result<(), RmsdError> {
   bool_c: false
 - uint_a: 128
   str_b: abd
-  bool_c: true"#
+  bool_c: true
+"#
     );
 
     assert_eq!(rmsd_yaml::from_str::<Vec<FooTest>>(&yaml_str)?, data);
@@ -108,7 +110,8 @@ uint_a:
   - 129
   - 128
   - 127
-str_b: abc"#
+str_b: abc
+"#
     );
 
     assert_eq!(rmsd_yaml::from_str::<FooTest>(&yaml_str)?, data);
@@ -132,7 +135,8 @@ fn test_nested_array() -> Result<(), RmsdError> {
 - - 5
   - 6
   - 7
-  - 8"#
+  - 8
+"#
     );
 
     assert_eq!(rmsd_yaml::from_str::<FooTest>(&yaml_str)?, data);
@@ -171,7 +175,8 @@ bar:
     - 1
     - 2
     - 3
-    - 4"#
+    - 4
+"#
     );
 
     assert_eq!(rmsd_yaml::from_str::<FooTest>(&yaml_str)?, data);


### PR DESCRIPTION
Allow `YamlValueData::Null` to be parsed in `deserialize_map()`.

Integration test case included.